### PR TITLE
Update styles.php

### DIFF
--- a/inc/styles.php
+++ b/inc/styles.php
@@ -526,7 +526,8 @@ class SiteOrigin_Panels_Styles {
 			}
 
 			// Add in flexbox alignment to the main row element
-			if ( ! empty( $row['style']['cell_alignment'] ) ) {
+			$flexbox_align_styles = array('auto','flex-start', 'center', 'flex-end', 'stretch');
+			if ( ! empty( $row['style']['cell_alignment'] ) && in_array($row['style']['cell_alignment'], $flexbox_align_styles ) ) {
 				$css->add_row_css(
 					$post_id,
 					$ri,


### PR DESCRIPTION
Currently Page builder is limited to flexbox for vertical alignment. 
In case of extending vertical alignment options, this patch prevents errors in css output.